### PR TITLE
Allow for specifying 'MODULE_PATH'.

### DIFF
--- a/template/golang-http-distroless-debug/.dockerignore
+++ b/template/golang-http-distroless-debug/.dockerignore
@@ -1,4 +1,5 @@
 Dockerfile
 template.yml
 function/vendor/github.com/openfaas-incubator/go-function-sdk
+function/function/vendor/github.com/openfaas-incubator/go-function-sdk
 vendor/handler

--- a/template/golang-http-distroless-debug/Dockerfile
+++ b/template/golang-http-distroless-debug/Dockerfile
@@ -9,11 +9,14 @@ ARG GO111MODULE="off"
 ARG GOFLAGS=""
 ARG GOPRIVATE=""
 ARG GOPROXY=""
+ARG MODULE_PATH="handler"
 RUN --mount=type=cache,target=/root/.cache/go-build go get -u github.com/go-delve/delve/cmd/dlv
-RUN mkdir -p /go/src/handler
-WORKDIR /go/src/handler
 RUN [ "${GITHUB_USERNAME}" != "" ] && echo "machine github.com login ${GITHUB_USERNAME} password ${GITHUB_TOKEN}" >> /root/.netrc || :
+RUN mkdir -p /go/src/$MODULE_PATH
+WORKDIR /go/src/$MODULE_PATH
 COPY . .
+RUN mv ./function ./function.tmp && mv ./function.tmp/function . && rm -rf ./function.tmp
+RUN sed -i "s|handler/function|$MODULE_PATH/function|g" go.mod handler.go
 RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 go build -gcflags "all=-N -l" -o /handler -tags netgo -v .
 
 FROM gcr.io/distroless/base:debug

--- a/template/golang-http-distroless/.dockerignore
+++ b/template/golang-http-distroless/.dockerignore
@@ -1,4 +1,5 @@
 Dockerfile
 template.yml
 function/vendor/github.com/openfaas-incubator/go-function-sdk
+function/function/vendor/github.com/openfaas-incubator/go-function-sdk
 vendor/handler

--- a/template/golang-http-distroless/Dockerfile
+++ b/template/golang-http-distroless/Dockerfile
@@ -9,10 +9,13 @@ ARG GO111MODULE="off"
 ARG GOFLAGS=""
 ARG GOPRIVATE=""
 ARG GOPROXY=""
-RUN mkdir -p /go/src/handler
-WORKDIR /go/src/handler
+ARG MODULE_PATH="handler"
 RUN [ "${GITHUB_USERNAME}" != "" ] && echo "machine github.com login ${GITHUB_USERNAME} password ${GITHUB_TOKEN}" >> /root/.netrc || :
+RUN mkdir -p /go/src/$MODULE_PATH
+WORKDIR /go/src/$MODULE_PATH
 COPY . .
+RUN mv ./function ./function.tmp && mv ./function.tmp/function . && rm -rf ./function.tmp
+RUN sed -i "s|handler/function|$MODULE_PATH/function|g" go.mod handler.go
 RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 go build --ldflags='-d -s -w' -o /handler -tags netgo -v .
 
 FROM gcr.io/distroless/static:nonroot


### PR DESCRIPTION
This PR allows for specifying `MODULE_PATH` via a build argument. This is helpful in order to make local paths consistent with remote paths when using the debug template.